### PR TITLE
Add checkpoint resume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,17 @@ wget https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakesp
 python train.py --data data.txt --epochs 1
 ```
 
-This will save a model checkpoint to `checkpoints/model.pth`.
+This will save a model checkpoint to `checkpoints/model.pth` as well as
+per-epoch checkpoints in the `checkpoints/` directory.
+
+To resume training from a saved checkpoint:
+
+```bash
+python train.py --data data.txt --epochs 5 --resume checkpoints/epoch_1.pth
+```
+
+The command above continues training until epoch five starting from the
+state saved in `epoch_1.pth`.
 
 ## Text Generation
 Generate text using the trained model:

--- a/train.py
+++ b/train.py
@@ -6,12 +6,27 @@ from torch.utils.data import Dataset, DataLoader
 from model import CharRNN
 
 class TextDataset(Dataset):
-    def __init__(self, text, seq_length=100):
+    def __init__(self, text, seq_length=100, vocab=None):
+        """Dataset of fixed-length character sequences.
+
+        Parameters
+        ----------
+        text : str
+            The training corpus.
+        seq_length : int
+            Length of each sequence used for training.
+        vocab : list or None
+            Optional list of vocabulary characters to use when encoding
+            ``text``. When ``None`` the vocabulary is built from the text.
+        """
         self.seq_length = seq_length
-        self.vocab = sorted(list(set(text)))
+        if vocab is None:
+            self.vocab = sorted(list(set(text)))
+        else:
+            self.vocab = vocab
         self.char2idx = {ch: i for i, ch in enumerate(self.vocab)}
         self.idx2char = {i: ch for ch, i in self.char2idx.items()}
-        self.data = [self.char2idx[ch] for ch in text]
+        self.data = [self.char2idx[ch] for ch in text if ch in self.char2idx]
 
     def __len__(self):
         return len(self.data) - self.seq_length
@@ -35,9 +50,33 @@ def train(model, dataloader, optimizer, criterion, device):
         total_loss += loss.item()
     return total_loss / len(dataloader)
 
-def train_model(text, seq_length=100, epochs=1, batch_size=64, lr=0.002, device=None):
-    """Train a character level model and return it along with the vocab and losses."""
-    dataset = TextDataset(text, seq_length=seq_length)
+def train_model(text, seq_length=100, epochs=1, batch_size=64, lr=0.002, device=None, resume=None):
+    """Train a character level model and return it along with the vocab and losses.
+
+    Parameters
+    ----------
+    text : str
+        Training corpus.
+    seq_length : int
+        Length of each training sequence.
+    epochs : int
+        Total number of epochs to train.
+    batch_size : int
+        Mini-batch size.
+    lr : float
+        Learning rate.
+    device : torch.device or None
+        Device to run training on. If ``None`` a CUDA device is used when
+        available.
+    resume : str or None
+        Optional path to a checkpoint from which to resume training.
+    """
+
+    ckpt = None
+    if resume is not None and os.path.isfile(resume):
+        ckpt = torch.load(resume, map_location=device or 'cpu')
+
+    dataset = TextDataset(text, seq_length=seq_length, vocab=ckpt.get('vocab') if ckpt else None)
     dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
 
     if device is None:
@@ -46,11 +85,30 @@ def train_model(text, seq_length=100, epochs=1, batch_size=64, lr=0.002, device=
     optimizer = torch.optim.Adam(model.parameters(), lr=lr)
     criterion = nn.CrossEntropyLoss()
 
+    start_epoch = 1
     losses = []
-    for epoch in range(epochs):
+    if ckpt:
+        model.load_state_dict(ckpt['model_state_dict'])
+        if 'optimizer_state_dict' in ckpt:
+            optimizer.load_state_dict(ckpt['optimizer_state_dict'])
+        start_epoch = ckpt.get('epoch', 0) + 1
+        losses = ckpt.get('losses', [])
+
+    for epoch in range(start_epoch, epochs + 1):
         loss = train(model, dataloader, optimizer, criterion, device)
         losses.append(loss)
-        print(f"Epoch {epoch+1}/{epochs} Loss: {loss:.4f}")
+        print(f"Epoch {epoch}/{epochs} Loss: {loss:.4f}")
+
+        os.makedirs('checkpoints', exist_ok=True)
+        ckpt_path = os.path.join('checkpoints', f'epoch_{epoch}.pth')
+        torch.save({
+            'model_state_dict': model.state_dict(),
+            'optimizer_state_dict': optimizer.state_dict(),
+            'vocab': dataset.vocab,
+            'epoch': epoch,
+            'losses': losses,
+        }, ckpt_path)
+
     return model, dataset.vocab, losses
 
 
@@ -61,6 +119,7 @@ def main():
     parser.add_argument('--epochs', type=int, default=1)
     parser.add_argument('--batch_size', type=int, default=64)
     parser.add_argument('--lr', type=float, default=0.002)
+    parser.add_argument('--resume', type=str, help='path to checkpoint to resume from')
     args = parser.parse_args()
 
     with open(args.data, 'r') as f:
@@ -74,9 +133,11 @@ def main():
         batch_size=args.batch_size,
         lr=args.lr,
         device=device,
+        resume=args.resume,
     )
     os.makedirs('checkpoints', exist_ok=True)
-    torch.save({'model_state_dict': model.state_dict(), 'vocab': vocab}, 'checkpoints/model.pth')
+    final_path = os.path.join('checkpoints', 'model.pth')
+    torch.save({'model_state_dict': model.state_dict(), 'vocab': vocab}, final_path)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- enable resuming training with a `--resume` flag
- save optimizer and model state after each epoch in `checkpoints/`
- document how to resume training from saved checkpoints

## Testing
- `python -m py_compile train.py model.py generate.py gui.py`
- `pip install torch` *(fails: cannot install large packages)*

------
https://chatgpt.com/codex/tasks/task_e_684cf722565c832a8adb5dfdd0a7bcf1