### PR TITLE
Add tokenizer support and preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Install dependencies with:
 
 ```bash
 pip install torch matplotlib
+# optional for subword tokenization
+pip install sentencepiece
 ```
 
 ## Training
@@ -23,6 +25,20 @@ python train.py --data data.txt --epochs 1
 
 This will save a model checkpoint to `checkpoints/model.pth`.
 
+### Subword Tokenization
+Install the optional `sentencepiece` package to enable subword tokenization.
+First train or load a tokenizer and preprocess the text:
+
+```bash
+python preprocess.py --data data.txt --model_prefix spm --vocab_size 8000 --output data.pt
+```
+
+Then train the model on the tokenized dataset:
+
+```bash
+python train.py --tokenized_data data.pt --epochs 1
+```
+
 ## Text Generation
 Generate text using the trained model:
 
@@ -30,7 +46,13 @@ Generate text using the trained model:
 python generate.py --checkpoint checkpoints/model.pth --start "Once upon a time"
 ```
 
-This prints generated characters to stdout.
+To use the subword tokenizer at generation time, pass the tokenizer model:
+
+```bash
+python generate.py --checkpoint checkpoints/model.pth --tokenizer spm.model --start "Once upon a time"
+```
+
+This prints generated text to stdout.
 
 ## Graphical Interface
 An optional GUI helps run training and visualize progress. Launch it with:

--- a/generate.py
+++ b/generate.py
@@ -1,11 +1,19 @@
 import argparse
 import torch
 from model import CharRNN
+try:
+    import sentencepiece as spm
+except ImportError:  # optional dependency
+    spm = None
 
 @torch.no_grad()
-def generate(model, start, char2idx, idx2char, length=200, device='cpu'):
+def generate(model, start, length=200, device='cpu', tokenizer=None, char2idx=None, idx2char=None):
+    """Generate text starting from ``start`` using either a tokenizer or raw characters."""
     model.eval()
-    indices = [char2idx[ch] for ch in start]
+    if tokenizer is not None:
+        indices = tokenizer.encode(start, out_type=int)
+    else:
+        indices = [char2idx[ch] for ch in start]
     input_tensor = torch.tensor(indices, dtype=torch.long).unsqueeze(0).to(device)
     hidden = None
     for _ in range(length):
@@ -14,24 +22,30 @@ def generate(model, start, char2idx, idx2char, length=200, device='cpu'):
         idx = torch.multinomial(prob, 1).item()
         indices.append(idx)
         input_tensor = torch.tensor([idx], dtype=torch.long).unsqueeze(0).to(device)
-    return ''.join(idx2char[i] for i in indices)
+    if tokenizer is not None:
+        return tokenizer.decode(indices)
+    else:
+        return ''.join(idx2char[i] for i in indices)
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--checkpoint', default='checkpoints/model.pth')
     parser.add_argument('--start', default='Once upon a time')
     parser.add_argument('--length', type=int, default=200)
+    parser.add_argument('--tokenizer', help='SentencePiece model for generation')
     args = parser.parse_args()
 
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     ckpt = torch.load(args.checkpoint, map_location=device)
     vocab = ckpt['vocab']
-    char2idx = {ch: i for i, ch in enumerate(vocab)}
-    idx2char = {i: ch for i, ch in enumerate(vocab)}
+    tok_path = args.tokenizer or ckpt.get('tokenizer')
+    tokenizer = spm.SentencePieceProcessor(model_file=tok_path) if tok_path and spm is not None else None
+    char2idx = {ch: i for i, ch in enumerate(vocab)} if tokenizer is None else None
+    idx2char = {i: ch for i, ch in enumerate(vocab)} if tokenizer is None else None
     model = CharRNN(len(vocab)).to(device)
     model.load_state_dict(ckpt['model_state_dict'])
 
-    text = generate(model, args.start, char2idx, idx2char, args.length, device)
+    text = generate(model, args.start, args.length, device, tokenizer, char2idx, idx2char)
     print(text)
 
 if __name__ == '__main__':

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,0 +1,40 @@
+import argparse
+import os
+import torch
+try:
+    import sentencepiece as spm
+except ImportError:
+    spm = None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train or load a tokenizer and convert text to token IDs")
+    parser.add_argument('--data', required=True, help='input text file')
+    parser.add_argument('--model', help='existing SentencePiece model')
+    parser.add_argument('--model_prefix', default='spm', help='prefix for training a new tokenizer')
+    parser.add_argument('--vocab_size', type=int, default=2000, help='vocabulary size when training')
+    parser.add_argument('--output', default='data.pt', help='where to save token IDs')
+    args = parser.parse_args()
+
+    if spm is None:
+        raise ImportError("sentencepiece is required for preprocessing")
+
+    if args.model and os.path.exists(args.model):
+        model_file = args.model
+    else:
+        spm.SentencePieceTrainer.train(input=args.data,
+                                       model_prefix=args.model_prefix,
+                                       vocab_size=args.vocab_size)
+        model_file = args.model_prefix + '.model'
+
+    sp = spm.SentencePieceProcessor(model_file=model_file)
+
+    with open(args.data, 'r') as f:
+        text = f.read()
+    ids = sp.encode(text, out_type=int)
+    torch.save({'ids': ids, 'tokenizer': model_file}, args.output)
+    print(f'Saved token IDs to {args.output}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add optional SentencePiece tokenizer integration
- support preprocessed tokenized datasets
- script to train/load tokenizer and produce token IDs
- update generation and training for tokenization
- document subword tokenization setup

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684cf83b9754832aa42a1a8af71bff29